### PR TITLE
Fix python(abi) generator (the one written in Python)

### DIFF
--- a/scripts/pythondistdeps.py
+++ b/scripts/pythondistdeps.py
@@ -13,10 +13,10 @@
 
 from __future__ import print_function
 import argparse
-from distutils.sysconfig import get_python_lib
 from os.path import dirname, sep
 import re
-from sys import argv, stdin
+from sys import argv, stdin, version_info
+from sysconfig import get_path
 from warnings import warn
 
 from packaging.requirements import Requirement as Requirement_
@@ -287,8 +287,9 @@ if __name__ == "__main__":
         if py_abi and (lower.endswith('.py') or lower.endswith('.pyc') or lower.endswith('.pyo')):
             if name not in py_deps:
                 py_deps[name] = []
-            purelib = get_python_lib(standard_lib=0, plat_specific=0).split(version[:3])[0]
-            platlib = get_python_lib(standard_lib=0, plat_specific=1).split(version[:3])[0]
+            running_python_version = '{}.{}'.format(*version_info[:2])
+            purelib = get_path('purelib').split(running_python_version)[0]
+            platlib = get_path('platlib').split(running_python_version)[0]
             for lib in (purelib, platlib):
                 if lib in f:
                     spec = ('==', f.split(lib)[1].split(sep)[0])


### PR DESCRIPTION
There were three problems:

 - sys.version was not imported
 - sys.version[:3] is not reliable on Python 3.10+
 - distutils is deprecated on Python 3.10+

We were not hit by the missing import in Fedora because we only run the script
on .dist-info/.egg-info/.egg and not on .py files, so this if-branch never runs.

But when the script was fed with a .py path, it errored:

    Traceback (most recent call last):
      File "/usr/lib/rpm/pythondistdeps.py", line 344, in <module>
        purelib = get_python_lib(standard_lib=0, plat_specific=0).split(version[:3])[0]
    NameError: name 'version' is not defined

The sys.version[:3] thing kinda works for Python 3.10+ because *in this
particular case* splitting on '3.1' and taking the prefix yields the same
results as splitting on '3.10', but I consider that mere coincidence.

Finally, since the distutils import happened at module-level,
we got the Deprecation warning in all Fedora's Python packages:

    /usr/lib/rpm/pythondistdeps.py:16: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12